### PR TITLE
Improve cache file handling and YAML frontmatter escaping

### DIFF
--- a/wp-agent-feed.php
+++ b/wp-agent-feed.php
@@ -107,11 +107,39 @@ function waf_generate_cache( $post_id ) {
 
 	if ( ! is_dir( WAF_CACHE_DIR ) ) {
 		wp_mkdir_p( WAF_CACHE_DIR );
-		file_put_contents( WAF_CACHE_DIR . '.htaccess', "# Apache 2.4+\n<IfModule mod_authz_core.c>\n\tRequire all denied\n</IfModule>\n\n# Apache 2.2\n<IfModule !mod_authz_core.c>\n\tDeny from all\n</IfModule>\n" );
-		file_put_contents( WAF_CACHE_DIR . 'index.html', '' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( WAF_CACHE_DIR . '.htaccess', "# Apache 2.4+\n<IfModule mod_authz_core.c>\n\tRequire all denied\n</IfModule>\n\n# Apache 2.2\n<IfModule !mod_authz_core.c>\n\tDeny from all\n</IfModule>\n" ) ) {
+			// translators: %s is the cache directory path.
+			error_log( sprintf( 'WP Agent Feed: Failed to create .htaccess in %s', WAF_CACHE_DIR ) );
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( WAF_CACHE_DIR . 'index.html', '' ) ) {
+			// translators: %s is the cache directory path.
+			error_log( sprintf( 'WP Agent Feed: Failed to create index.html in %s', WAF_CACHE_DIR ) );
+		}
 	}
 
-	return file_put_contents( waf_cache_path( $post_id ), $markdown ) !== false;
+	$dest = waf_cache_path( $post_id );
+	$tmp  = $dest . '.tmp';
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	if ( false === file_put_contents( $tmp, $markdown, LOCK_EX ) ) {
+		// translators: %s is the temp file path.
+		error_log( sprintf( 'WP Agent Feed: Failed to write temp cache %s', $tmp ) );
+		return false;
+	}
+
+	// rename() is atomic on the same filesystem.
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+	if ( ! rename( $tmp, $dest ) ) {
+		// translators: %1$s is the temp path, %2$s is the destination path.
+		error_log( sprintf( 'WP Agent Feed: Failed to rename %1$s to %2$s', $tmp, $dest ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $tmp );
+		return false;
+	}
+
+	return true;
 }
 
 /**
@@ -149,13 +177,13 @@ function waf_build_frontmatter( $post ) {
 		'---',
 		'title: "' . waf_escape_yaml( $title ) . '"',
 		'description: "' . waf_escape_yaml( $description ) . '"',
-		'url: ' . $url,
+		'url: "' . waf_escape_yaml( $url ) . '"',
 		'date: ' . $date,
 		'modified: ' . $modified,
 	];
 
 	if ( $image ) {
-		$lines[] = 'image: ' . $image;
+		$lines[] = 'image: "' . waf_escape_yaml( $image ) . '"';
 	}
 
 	$lines[] = '---';


### PR DESCRIPTION
## Summary
This PR improves the reliability and correctness of the cache generation process by implementing atomic file writes and proper YAML escaping for frontmatter fields.

## Key Changes
- **Atomic cache file writes**: Replaced direct file writes with a temporary file + rename pattern to ensure cache files are written atomically, preventing corruption if the process is interrupted
- **Error handling**: Added error logging for all file operations (`.htaccess`, `index.html`, and cache file creation) to help diagnose issues
- **YAML escaping**: Applied `waf_escape_yaml()` to the `url` and `image` frontmatter fields and wrapped them in quotes to ensure special characters are properly escaped
- **PHP CodeSniffer compliance**: Added appropriate `phpcs:ignore` comments for file system operations that intentionally use native PHP functions instead of WordPress alternatives

## Implementation Details
- Cache files are now written to a temporary file with `.tmp` extension, then atomically renamed to the final destination using `rename()`, which is atomic on the same filesystem
- If the temporary file write fails, the function returns `false` immediately
- If the rename fails, the temporary file is cleaned up before returning `false`
- All error messages are logged via `error_log()` with translatable strings for better debugging
- YAML frontmatter fields that may contain special characters are now properly quoted and escaped

https://claude.ai/code/session_0146kfk2GkrjK73bVpvzAkXH