### PR TITLE
fix: strip_tags() によるコードブロック内 HTML タグ破壊を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .phpcs.cache
 .wp-env/
 .wp-env.override.json
+.claude/tmp/

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -288,4 +288,95 @@ final class FunctionsTest extends TestCase {
 		$path = waf_cache_path( 'abc' );
 		$this->assertSame( WAF_CACHE_DIR . '0.md', $path );
 	}
+
+	// =========================================================
+	// Code block preservation in waf_html_to_markdown()
+	// =========================================================
+
+	#[Test]
+	public function code_block_preserves_html_tags(): void {
+		$html = '<pre><code class="language-html">&lt;div class=&quot;container&quot;&gt;&lt;p&gt;Hello&lt;/p&gt;&lt;/div&gt;</code></pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '```html', $md );
+		$this->assertStringContainsString( '<div class="container"><p>Hello</p></div>', $md );
+	}
+
+	#[Test]
+	public function multiple_code_blocks_preserve_html_tags(): void {
+		$html  = '<p>Intro</p>';
+		$html .= '<pre><code class="language-html">&lt;div&gt;first&lt;/div&gt;</code></pre>';
+		$html .= '<p>Middle</p>';
+		$html .= '<pre><code>&lt;span&gt;second&lt;/span&gt;</code></pre>';
+		$html .= '<p>End</p>';
+		$md    = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '<div>first</div>', $md );
+		$this->assertStringContainsString( '<span>second</span>', $md );
+		$this->assertStringContainsString( 'Intro', $md );
+		$this->assertStringContainsString( 'Middle', $md );
+		$this->assertStringContainsString( 'End', $md );
+	}
+
+	#[Test]
+	public function pre_without_code_preserves_html_tags(): void {
+		$html = '<pre>&lt;p&gt;Hello&lt;/p&gt;</pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '<p>Hello</p>', $md );
+	}
+
+	#[Test]
+	public function remaining_tags_stripped_with_code_block(): void {
+		$html  = '<div><span>visible text</span></div>';
+		$html .= '<pre><code class="language-html">&lt;div&gt;code content&lt;/div&gt;</code></pre>';
+		$md    = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( 'visible text', $md );
+		$this->assertStringContainsString( '<div>code content</div>', $md );
+	}
+
+	#[Test]
+	public function code_block_entities_not_double_decoded(): void {
+		$html = '<pre><code>&amp;amp; entity</code></pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '&amp; entity', $md );
+	}
+
+	#[Test]
+	public function blockquote_with_code_block_preserves_html(): void {
+		$html = '<blockquote><pre><code class="language-html">&lt;div&gt;quoted code&lt;/div&gt;</code></pre></blockquote>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '<div>quoted code</div>', $md );
+	}
+
+	#[Test]
+	public function code_block_preserves_p_br_hr_tags(): void {
+		$html = '<pre><code class="language-html">&lt;p&gt;para&lt;/p&gt;&lt;br&gt;&lt;hr&gt;</code></pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '<p>para</p><br><hr>', $md );
+	}
+
+	#[Test]
+	public function code_block_with_blockquote_fence_inside(): void {
+		// A top-level code block containing "> ```" should not terminate early.
+		$html = '<pre><code>&gt; ```' . "\n" . 'content' . "\n" . '&gt; ```</code></pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( '> ```', $md );
+		$this->assertStringContainsString( 'content', $md );
+	}
+
+	#[Test]
+	public function empty_fenced_code_block(): void {
+		$html = '<pre><code></code></pre>';
+		$md   = waf_html_to_markdown( $html );
+		$this->assertStringContainsString( "```\n\n```", $md );
+	}
+
+	#[Test]
+	public function crlf_fenced_code_block(): void {
+		// Simulate CRLF line endings in a fenced code block produced by waf_convert_code_blocks.
+		// We test waf_cleanup_markdown directly with pre-built fenced content.
+		$input = "```html\r\n<div>test</div>\r\n```\r\n";
+		// waf_cleanup_markdown is called within waf_html_to_markdown pipeline,
+		// but we can call it directly to test CRLF handling.
+		$result = waf_cleanup_markdown( $input );
+		$this->assertStringContainsString( '<div>test</div>', $result );
+	}
 }

--- a/wp-agent-feed.php
+++ b/wp-agent-feed.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Agent Feed
- * Plugin URI: https://github.com/your-repo/wp-agent-feed
+ * Plugin URI: https://github.com/yamtd/wp-agent-feed
  * Description: Accept: text/markdown ヘッダー付きリクエストに対して、投稿コンテンツをMarkdownで返す。保存時に静的キャッシュを生成するパフォーマンス重視設計。
  * Version: 1.2.0
  * Requires PHP: 7.4
@@ -354,6 +354,18 @@ function waf_convert_inline( $md ) {
 }
 
 function waf_cleanup_markdown( $md ) {
+	// フェンスドコードブロックをプレースホルダーに退避（全変換から保護）
+	$placeholders = array();
+	$md           = preg_replace_callback(
+		'/^(?<q>(?:>\h?)*)```[^\r\n]*\R(?:.*\R)*?\k<q>```[ \t]*\r?$/m',
+		function ( $m ) use ( &$placeholders ) {
+			$key                  = '__WAF_CODE_BLOCK_' . count( $placeholders ) . '__';
+			$placeholders[ $key ] = $m[0];
+			return $key;
+		},
+		$md
+	);
+
 	// 段落
 	$md = preg_replace( '/<p[^>]*>/si', "\n", $md );
 	$md = str_replace( '</p>', "\n", $md );
@@ -369,6 +381,9 @@ function waf_cleanup_markdown( $md ) {
 
 	// HTMLエンティティをデコード
 	$md = html_entity_decode( $md, ENT_QUOTES, 'UTF-8' );
+
+	// コードブロックを復元
+	$md = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $md );
 
 	// 連続空行を正規化
 	$md = preg_replace( '/\n{3,}/', "\n\n", $md );


### PR DESCRIPTION
## Summary

- `waf_cleanup_markdown()` の `strip_tags()` がフェンスドコードブロック内の HTML タグまで除去していた致命的な不具合を修正
- コードブロックをプレースホルダーに退避してから `strip_tags()` / `html_entity_decode()` / `<p>/<br>/<hr>` 変換を適用し、その後復元する方式
- 正規表現は名前付き後方参照で開閉フェンスのブロック引用プレフィックスを一致させ、LF/CRLF・空ブロックにも対応

## Test plan

- [x] `composer check` (PHPCS lint + PHPUnit) 全 43 テスト通過
- [ ] Docker 環境で HTML コード例を含む投稿を作成し、`curl -H "Accept: text/markdown"` でコードブロック内のタグが保持されることを確認
- [ ] ブロック引用内のコードブロックでも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)