### PR TITLE
Add .gitattributes to exclude development files from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Exclude development files from GitHub source archives (`git archive`)
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.phpcs.xml.dist    export-ignore
+/.wp-env.json       export-ignore
+/CLAUDE.md          export-ignore
+/composer.json      export-ignore
+/composer.lock      export-ignore
+/phpunit.xml.dist   export-ignore
+/tests/             export-ignore


### PR DESCRIPTION
## Summary
This change adds a `.gitattributes` file to configure Git's export behavior, ensuring that development and configuration files are excluded from source code archives generated via `git archive`.

## Key Changes
- Created `.gitattributes` with `export-ignore` directives for development files including:
  - Editor configuration (`.editorconfig`)
  - Git configuration files (`.gitattributes`, `.gitignore`)
  - Code quality tools (`.phpcs.xml.dist`, `phpunit.xml.dist`)
  - Development environment setup (`.wp-env.json`)
  - Dependency management (`composer.json`, `composer.lock`)
  - Documentation (`CLAUDE.md`)
  - Test suite (`/tests/` directory)

## Benefits
- Reduces the size of distributed source archives by excluding unnecessary development files
- Provides a cleaner distribution package for end users
- Maintains development tooling in the repository without cluttering releases

https://claude.ai/code/session_018zyBELZbcsRACPG9P7cVft