### PR TITLE
Add robots.txt protection, settings link, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,21 @@ wp-content/plugins/wp-agent-feed/wp-agent-feed.php
 
 に配置し、管理画面 > プラグインから「WP Agent Feed」を有効化。
 
-### Nginx の場合
+### キャッシュディレクトリの保護
 
-Apache では .htaccess で自動保護されるが、Nginx の場合はキャッシュディレクトリへの
-直接アクセスをブロックする設定を追加する:
+- **Apache**: `.htaccess` で直接アクセスを自動ブロック（プラグインが生成）
+- **クローラー**: `robots.txt` に `Disallow` ルールを自動追加（SEO 重複コンテンツ対策）
+- **Nginx**: `robots.txt` による保護は自動適用される。直接アクセスもブロックしたい場合は以下を任意で追加:
 
-```nginx
-location ~* ^/wp-content/cache/markdown/ {
-    deny all;
-    return 403;
-}
-```
+  ```nginx
+  location ~* ^/wp-content/cache/markdown/ {
+      deny all;
+      return 403;
+  }
+  ```
+
+> **注意**: キャッシュファイルの内容は公開済み投稿の Markdown 変換です。
+> `robots.txt` は主要検索エンジンのクローラーに対して有効ですが、直接アクセスをブロックするものではありません。
 
 ## 動作確認
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 // Plugin constants — define before loading the plugin so
 // the if-not-defined blocks are satisfied.
 if ( ! defined( 'WpAgentFeed\CACHE_DIR' ) ) {
-	define( 'WpAgentFeed\CACHE_DIR', sys_get_temp_dir() . '/waf-test-cache/' );
+	define( 'WpAgentFeed\CACHE_DIR', ABSPATH . 'wp-content/cache/markdown/' );
 }
 if ( ! defined( 'WpAgentFeed\POST_TYPES' ) ) {
 	define( 'WpAgentFeed\POST_TYPES', [ 'post', 'page' ] );

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -11,6 +11,8 @@ use function WpAgentFeed\estimate_tokens;
 use function WpAgentFeed\cache_path;
 use function WpAgentFeed\is_overridden;
 use function WpAgentFeed\clear_all_cache;
+use function WpAgentFeed\robots_disallow_path;
+use function WpAgentFeed\filter_robots_txt;
 use const WpAgentFeed\CACHE_DIR;
 
 /**
@@ -483,5 +485,74 @@ final class FunctionsTest extends TestCase {
 
 		// Restore directory for other tests.
 		mkdir( $original_dir, 0755, true );
+	}
+
+	/* ========================================
+	 * robots_disallow_path() テスト
+	 * ======================================== */
+
+	#[Test]
+	public function robots_disallow_path_standard(): void {
+		$this->assertSame(
+			'/wp-content/cache/markdown/',
+			robots_disallow_path( '/var/www/html/', '/var/www/html/wp-content/cache/markdown/' )
+		);
+	}
+
+	#[Test]
+	public function robots_disallow_path_subdirectory_install(): void {
+		$this->assertSame(
+			'/wp-content/cache/markdown/',
+			robots_disallow_path( '/var/www/html/blog/', '/var/www/html/blog/wp-content/cache/markdown/' )
+		);
+	}
+
+	#[Test]
+	public function robots_disallow_path_outside_abspath(): void {
+		$this->assertSame(
+			'',
+			robots_disallow_path( '/var/www/html/', '/var/cache/markdown/' )
+		);
+	}
+
+	#[Test]
+	public function robots_disallow_path_same_as_abspath(): void {
+		$this->assertSame(
+			'',
+			robots_disallow_path( '/var/www/html/', '/var/www/html/' )
+		);
+	}
+
+	/* ========================================
+	 * filter_robots_txt() テスト
+	 * ======================================== */
+
+	#[Test]
+	public function filter_robots_txt_adds_disallow_rule(): void {
+		$input  = "User-agent: *\nDisallow: /wp-admin/\nAllow: /wp-admin/admin-ajax.php\n";
+		$output = filter_robots_txt( $input, 1 );
+		$this->assertStringContainsString( 'Disallow: /wp-content/cache/markdown/', $output );
+	}
+
+	#[Test]
+	public function filter_robots_txt_skips_duplicate(): void {
+		$input  = "User-agent: *\nDisallow: /wp-content/cache/markdown/\n";
+		$output = filter_robots_txt( $input, 1 );
+		$this->assertSame( 1, substr_count( $output, 'Disallow: /wp-content/cache/markdown/' ) );
+	}
+
+	#[Test]
+	public function filter_robots_txt_distinguishes_similar_path(): void {
+		$input  = "User-agent: *\nDisallow: /wp-content/cache/markdown/sub/\n";
+		$output = filter_robots_txt( $input, 1 );
+		$this->assertStringContainsString( 'Disallow: /wp-content/cache/markdown/sub/', $output );
+		$this->assertStringContainsString( "\nDisallow: /wp-content/cache/markdown/\n", $output );
+	}
+
+	#[Test]
+	public function filter_robots_txt_skips_duplicate_with_crlf(): void {
+		$input  = "User-agent: *\r\nDisallow: /wp-content/cache/markdown/\r\n";
+		$output = filter_robots_txt( $input, 1 );
+		$this->assertSame( 1, substr_count( $output, 'Disallow: /wp-content/cache/markdown/' ) );
 	}
 }

--- a/wp-agent-feed.php
+++ b/wp-agent-feed.php
@@ -47,6 +47,8 @@ add_action(
 	}
 );
 
+add_filter( 'robots_txt', __NAMESPACE__ . '\filter_robots_txt', 10, 2 );
+
 /* ========================================
  * 1. 早期インターセプト — Accept ヘッダーの確認とキャッシュ配信
  * ======================================== */
@@ -494,6 +496,46 @@ function is_overridden( $name = '', $mark = false, $reset = false ) {
 		$overrides[ $name ] = true;
 	}
 	return isset( $overrides[ $name ] );
+}
+
+/**
+ * CACHE_DIR の URL 相対パスを返す。Web 非公開の場合は空文字列。
+ *
+ * @param string $abspath   WordPress ルート絶対パス（末尾スラッシュ付き）。
+ * @param string $cache_dir キャッシュディレクトリ絶対パス。
+ * @return string URL 相対パス（例: /wp-content/cache/markdown/）または空文字列。
+ */
+function robots_disallow_path( $abspath, $cache_dir ) {
+	if ( 0 !== strpos( $cache_dir, $abspath ) ) {
+		return '';
+	}
+	$relative = substr( $cache_dir, strlen( $abspath ) );
+	if ( '' === $relative || false === $relative ) {
+		return '';
+	}
+	return '/' . $relative;
+}
+
+/**
+ * robots.txt に Disallow ルールを追加するフィルターコールバック。
+ *
+ * @param string $output robots.txt の出力文字列。
+ * @param int    $public サイトの公開設定。
+ * @return string フィルター済み出力。
+ */
+function filter_robots_txt( $output, $public ) {
+	$path = robots_disallow_path( ABSPATH, CACHE_DIR );
+	if ( '' === $path ) {
+		return $output;
+	}
+
+	$rule = 'Disallow: ' . $path;
+	if ( preg_match( '/^' . preg_quote( $rule, '/' ) . '\r?$/m', $output ) ) {
+		return $output;
+	}
+
+	$output .= "\n" . $rule . "\n";
+	return $output;
 }
 
 function cache_path( $post_id ) {


### PR DESCRIPTION
## Summary

- **robots.txt 自動保護**: キャッシュディレクトリへのクローラーアクセスを `Disallow` ルールで自動ブロック（SEO 重複コンテンツ対策）
- **Settings リンク追加**: プラグイン一覧画面に設定ページへの直リンクを追加
- **README 更新**: 管理画面の設定・キャッシュ管理・多言語対応・保護方法の記述を現状に合わせて更新

Closes #14

## Test plan

- [ ] `composer check` (lint + test) がパス
- [ ] `curl -s https://example.com/robots.txt` に `Disallow: /wp-content/cache/markdown/` が含まれる
- [ ] robots.txt に既にルールがある場合、重複追加されない
- [ ] `CACHE_DIR` を `ABSPATH` 外に設定した場合、ルールが追加されない
- [ ] プラグイン一覧に「Settings」リンクが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)