### PR TITLE
Harden HTTP header value handling in WP Agent Feed

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -133,7 +133,7 @@ function register_settings() {
  * @return string Sanitized value.
  */
 function sanitize_content_signal( $value ) {
-	$value = sanitize_text_field( $value );
+	$value = normalize_header_value( $value );
 	if ( '' === $value ) {
 		return 'ai-train=no, search=yes, ai-input=yes';
 	}
@@ -147,8 +147,7 @@ function sanitize_content_signal( $value ) {
  * @return string Sanitized value (empty string disables the header).
  */
 function sanitize_cache_control( $value ) {
-	$value = sanitize_text_field( $value );
-	return str_replace( array( "\r", "\n" ), '', $value );
+	return normalize_header_value( $value );
 }
 
 /**
@@ -751,11 +750,12 @@ function ajax_live_test() {
 		'Content-Type'      => 'text/markdown; charset=utf-8',
 		'Vary'              => 'Accept',
 		'X-Markdown-Tokens' => (string) $token_count,
-		'Content-Signal'    => CONTENT_SIGNAL,
+		'Content-Signal'    => normalize_header_value( CONTENT_SIGNAL ),
 		'Content-Length'    => (string) strlen( $body ),
 	);
-	if ( CACHE_CONTROL !== '' ) {
-		$headers['Cache-Control'] = CACHE_CONTROL;
+	$cache_control = normalize_header_value( CACHE_CONTROL );
+	if ( '' !== $cache_control ) {
+		$headers['Cache-Control'] = $cache_control;
 	}
 
 	wp_send_json_success(

--- a/wp-agent-feed.php
+++ b/wp-agent-feed.php
@@ -37,7 +37,7 @@ if ( ! defined( __NAMESPACE__ . '\POST_TYPES' ) ) {
 if ( ! defined( __NAMESPACE__ . '\CONTENT_SIGNAL' ) ) {
 	define(
 		__NAMESPACE__ . '\CONTENT_SIGNAL',
-		get_option( 'wp_agent_feed_content_signal', 'ai-train=no, search=yes, ai-input=yes' )
+		normalize_header_value( get_option( 'wp_agent_feed_content_signal', 'ai-train=no, search=yes, ai-input=yes' ) )
 			?: 'ai-train=no, search=yes, ai-input=yes'
 	);
 } else {
@@ -46,7 +46,7 @@ if ( ! defined( __NAMESPACE__ . '\CONTENT_SIGNAL' ) ) {
 if ( ! defined( __NAMESPACE__ . '\CACHE_CONTROL' ) ) {
 	define(
 		__NAMESPACE__ . '\CACHE_CONTROL',
-		get_option( 'wp_agent_feed_cache_control', 'public, max-age=3600' )
+		normalize_header_value( get_option( 'wp_agent_feed_cache_control', 'public, max-age=3600' ) )
 	);
 } else {
 	is_overridden( 'CACHE_CONTROL', true );
@@ -101,10 +101,11 @@ function serve_markdown() {
 	header( 'Content-Type: text/markdown; charset=utf-8' );
 	header( 'Vary: Accept' );
 	header( 'X-Markdown-Tokens: ' . $token_count );
-	header( 'Content-Signal: ' . CONTENT_SIGNAL );
+	header( 'Content-Signal: ' . normalize_header_value( CONTENT_SIGNAL ) );
 	header( 'Content-Length: ' . strlen( $markdown ) );
-	if ( CACHE_CONTROL !== '' ) {
-		header( 'Cache-Control: ' . CACHE_CONTROL );
+	$cache_control = normalize_header_value( CACHE_CONTROL );
+	if ( '' !== $cache_control ) {
+		header( 'Cache-Control: ' . $cache_control );
 	}
 
 	echo $markdown;
@@ -450,11 +451,12 @@ function validate_markdown_output( $body, $content_signal ) {
 	);
 
 	// 4. Content-Signal configured.
-	$checks[] = array(
+	$normalized_content_signal = normalize_header_value( $content_signal );
+	$checks[]                 = array(
 		'name'   => 'content_signal',
-		'pass'   => '' !== $content_signal,
+		'pass'   => '' !== $normalized_content_signal,
 		'expect' => 'non-empty',
-		'actual' => '' !== $content_signal ? $content_signal : '(empty)',
+		'actual' => '' !== $normalized_content_signal ? $normalized_content_signal : '(empty)',
 	);
 
 	$pass = true;
@@ -659,6 +661,18 @@ function check_github_update( $update, $plugin_data, $plugin_file, $locales ) {
 		'url'     => $data['url'],
 		'package' => $data['package'],
 	);
+}
+
+/**
+ * HTTPヘッダー値を安全な1行文字列へ正規化。
+ *
+ * @param mixed $value Raw value.
+ * @return string Sanitized single-line header value.
+ */
+function normalize_header_value( $value ) {
+	$header = sanitize_text_field( (string) $value );
+	$header = str_replace( array( "\r", "\n" ), '', $header );
+	return trim( $header );
 }
 
 /* ========================================


### PR DESCRIPTION
### Motivation

- Prevent CR/LF injection / HTTP response splitting by ensuring any header values derived from options or constants are normalized to a safe single-line string before being defined or emitted. 
- Keep admin input sanitization, diagnostics, and live-test output consistent with the runtime header values so displayed values match what is actually sent.

### Description

- Added `normalize_header_value()` helper to sanitize, strip CR/LF, and trim header values into a single-line safe string. (new function in `wp-agent-feed.php`).
- Apply normalization when defining `CONTENT_SIGNAL` and `CACHE_CONTROL` constants from options so stored values are normalized at initialization. (`wp-agent-feed.php`).
- Use normalized values when emitting actual response headers in `serve_markdown()` and when building header previews in the admin live-test (`wp-agent-feed.php` and `includes/admin.php`).
- Updated admin sanitizers `sanitize_content_signal()` and `sanitize_cache_control()` to use the same normalization function for consistent input handling (`includes/admin.php`).

### Testing

- `php -l wp-agent-feed.php` succeeded with no syntax errors. 
- `php -l includes/admin.php` succeeded with no syntax errors. 
- `composer test` could not be executed in this environment because `phpunit` is not installed (test script failed with missing `phpunit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f0665008832eb3fd41ba4226391b)